### PR TITLE
Fix avatar_cache docstring

### DIFF
--- a/api/db/avatar_cache.py
+++ b/api/db/avatar_cache.py
@@ -1,5 +1,4 @@
-""" caching helpers for Avatar context and conversation.
-"""
+"""Caching helpers for avatar context and conversation."""
 import logging
 import time
 import asyncio


### PR DESCRIPTION
## Summary
- fix capitalization of avatar_cache docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6843991df83c83218f14e786e5d0898b

## Summary by Sourcery

Documentation:
- Correct capitalization in the avatar_cache docstring