### PR TITLE
Add get_current_user endpoint tests

### DIFF
--- a/tests/core/test_get_current_user.py
+++ b/tests/core/test_get_current_user.py
@@ -1,0 +1,72 @@
+import datetime
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from api.core.security import create_access_token, create_refresh_token
+from api.schemas.user import UserProfile
+
+
+@mock.patch("api.core.security.settings.SECRET_KEY", "test-key")
+def test_get_me_with_access_token(client: TestClient):
+    user = UserProfile(
+        id="user123",
+        email="user@example.com",
+        display_name="User",
+        avatar_url=None,
+        bio=None,
+        lang="en-US",
+        followers_count=0,
+        following_count=0,
+        created_at=datetime.datetime.utcnow(),
+        updated_at=datetime.datetime.utcnow(),
+        is_active=True,
+        is_verified=True,
+        is_admin=False,
+    )
+
+    async def mock_get_by_id(self, uid: str):
+        return user
+
+    with mock.patch("api.services.user.UserService.get_by_id", mock_get_by_id):
+        token = create_access_token(user.id)
+        response = client.get(
+            "/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+    assert data["display_name"] == user.display_name
+
+
+@mock.patch("api.core.security.settings.SECRET_KEY", "test-key")
+def test_get_me_with_refresh_token(client: TestClient):
+    user = UserProfile(
+        id="user123",
+        email="user@example.com",
+        display_name="User",
+        avatar_url=None,
+        bio=None,
+        lang="en-US",
+        followers_count=0,
+        following_count=0,
+        created_at=datetime.datetime.utcnow(),
+        updated_at=datetime.datetime.utcnow(),
+        is_active=True,
+        is_verified=True,
+        is_admin=False,
+    )
+
+    async def mock_get_by_id(self, uid: str):
+        return user
+
+    with mock.patch("api.services.user.UserService.get_by_id", mock_get_by_id):
+        token = create_refresh_token(user.id)
+        response = client.get(
+            "/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 401
+    assert "Cannot use refresh token" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add new tests verifying token handling for /auth/me

## Testing
- `pytest -k get_current_user -vv` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68439929ced48321943328dc53eff2f7

## Summary by Sourcery

Add tests for the get_current_user endpoint to validate correct handling of access and refresh tokens

Tests:
- Add tests for /api/v1/auth/me endpoint verifying successful response with a valid access token
- Add test verifying that using a refresh token to access /api/v1/auth/me returns a 401 error