### PR TITLE
Update alembic.ini header

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,4 +1,4 @@
-# filepath: /Users/republicalatuya/Desktop/LyoBackendNew/alembic.ini
+# Alembic configuration file
 # A generic, single database configuration.
 
 [alembic]


### PR DESCRIPTION
## Summary
- use generic comment in `alembic.ini`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68439926e72083219b0370800f2b009b

## Summary by Sourcery

Documentation:
- Replace filepath-specific comment with a generic header in alembic.ini